### PR TITLE
Add Preferred layout manager option and stretch Widget ID column

### DIFF
--- a/pygubudesigner/main.py
+++ b/pygubudesigner/main.py
@@ -499,6 +499,9 @@ class PygubuDesigner(object):
         # Setup ttk theme if changed
         theme = pref.get_option('ttk_theme')
         self._change_ttk_theme(theme)
+        
+        # Get the preferred default layout manager, in case it has changed.
+        self.tree_editor.default_layout_manager = pref.get_option('default_layout_manager')
     
     def ask_save_changes(self, message, detail=None, title=None):
         do_continue = False

--- a/pygubudesigner/preferences.py
+++ b/pygubudesigner/preferences.py
@@ -39,6 +39,7 @@ logger.info('Using configfile: %s', CONFIG_FILE)
 options = {
     'widget_set': {'values': '["tk", "ttk"]', 'default':'ttk'},
     'ttk_theme': {'default': 'default'},
+    'default_layout_manager': {'values': '["pack", "grid", "place"]', 'default':'pack'},
     'geometry': {
         'default': '640x480',
         },
@@ -168,6 +169,10 @@ class PreferencesUI(object):
         for key in ('widget_set',):
             cbox = builder.get_object(key)
             cbox.configure(values=options[key]['values'])
+            
+        # Preferred layout manager
+        cbox_layout_manager = builder.get_object('cbox_layout_manager')
+        cbox_layout_manager.configure(values=options['default_layout_manager']['values'])
         
         #Custom widgets
         self.cwtv = builder.get_object('cwtv')

--- a/pygubudesigner/ui/preferences_dialog.ui
+++ b/pygubudesigner/ui/preferences_dialog.ui
@@ -59,7 +59,6 @@
                             <layout manager="grid">
                               <property name="propagate">True</property>
                               <property name="sticky">ew</property>
-                              <property type="col" id="0" name="pad">0</property>
                               <property type="row" id="0" name="pad">4</property>
                             </layout>
                           </object>
@@ -83,6 +82,7 @@
                               <property name="propagate">True</property>
                               <property name="row">1</property>
                               <property name="sticky">ew</property>
+                              <property type="row" id="1" name="pad">0</property>
                             </layout>
                           </object>
                         </child>
@@ -93,6 +93,30 @@
                               <property name="column">1</property>
                               <property name="propagate">True</property>
                               <property name="row">1</property>
+                              <property type="row" id="1" name="pad">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="ttk.Label" id="lbl_preferred_layout_manager">
+                            <property name="text" translatable="yes">Preferred layout manager:</property>
+                            <layout manager="grid">
+                              <property name="column">0</property>
+                              <property name="propagate">True</property>
+                              <property name="row">2</property>
+                              <property name="sticky">ew</property>
+                              <property type="row" id="2" name="pad">4</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="pygubu.builder.widgets.combobox" id="cbox_layout_manager">
+                            <property name="keyvariable">string:default_layout_manager</property>
+                            <layout manager="grid">
+                              <property name="column">1</property>
+                              <property name="propagate">True</property>
+                              <property name="row">2</property>
+                              <property type="row" id="2" name="pad">4</property>
                             </layout>
                           </object>
                         </child>

--- a/pygubudesigner/ui/pygubu-ui.ui
+++ b/pygubudesigner/ui/pygubu-ui.ui
@@ -354,7 +354,7 @@
                                             <property name="column_anchor">w</property>
                                             <property name="heading_anchor">w</property>
                                             <property name="minwidth">200</property>
-                                            <property name="stretch">false</property>
+                                            <property name="stretch">true</property>
                                             <property name="text" translatable="yes">Widget Id</property>
                                             <property name="tree_column">True</property>
                                             <property name="visible">True</property>

--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -60,7 +60,18 @@ class WidgetsTreeEditor(object):
         self.previewer = app.previewer
         self.treedata = {}
         self.counter = Counter()
-        self.default_layout_manager = 'pack' # TODO: set from configuration
+
+        # Get the default layout manager based on the user's configuration.
+        self.__preferred_layout_manager_var = tk.StringVar()
+        current_default_layout = pref.get_option('default_layout_manager')
+        if not current_default_layout:
+            self.__preferred_layout_manager_var.set("pack")
+        else:
+            self.__preferred_layout_manager_var.set(current_default_layout)
+            
+        # Set the default layout manager
+        self.default_layout_manager = self.__preferred_layout_manager_var.get()
+        
         # Filter vars
         self.filter_on = False
         self.filtervar = app.builder.get_variable('filtervar')


### PR DESCRIPTION
There are 2 changes in this pull request:

1. When the Pane in the Object Tree is moved towards the right, the Widget ID column does not currently expand automatically. In other words, if the user wants to see the full name of a widget in the treeview, they have to do 2 things: move the pane to the right **and** also move the Widget ID column to the right. With this pull request, moving the pane to the right will automatically cause the Widget ID column to stretch with it. This seems like the most natural way of seeing a long widget name.
![expand_comparison2](https://user-images.githubusercontent.com/45316730/130632380-6850356b-036b-40c3-818b-5103bdb836ae.png)

2. The second change is a new 'Preferred layout manager' option in Edit -> Preferences. This will allow the user to change the default layout manager that Pygubu Designer uses when adding new widgets.
![layoutmanager](https://user-images.githubusercontent.com/45316730/130633033-8f87d4f1-9ad1-4bef-8b12-f236f7bf6269.png)
