### PR TITLE
Add context menu in design view + improve context menu

### DIFF
--- a/pygubudesigner/main.py
+++ b/pygubudesigner/main.py
@@ -169,7 +169,10 @@ class PygubuDesigner(object):
         # build main ui
         self.mainwindow = self.builder.get_object('mainwindow')
         menu = self.builder.get_object('mainmenu', self.mainwindow)
-        self.context_menu = self.builder.get_object("context_menu", self.mainwindow)
+        self.context_menu = self.builder.get_object('context_menu', self.mainwindow)
+        
+        # Initialize duplicate menu state
+        self.duplicate_menu_state = 'normal'
 
         if in_macos:
             cmd = 'tk::mac::ShowPreferences'
@@ -206,7 +209,8 @@ class PygubuDesigner(object):
 
         # Preview
         previewc = self.builder.get_object('preview_canvas')
-        self.previewer = PreviewHelper(previewc)
+        self.previewer = PreviewHelper(previewc, self)
+
         # tree editor
         self.tree_editor = WidgetsTreeEditor(self)
 
@@ -223,10 +227,10 @@ class PygubuDesigner(object):
         #
         if in_macos:
             # tree_editor context menu binding (2nd mouse button for macos)
-            self.tree_editor.treeview.bind("<2>", self.on_right_click_object_tree)
+            self.tree_editor.treeview.bind('<2>', self.on_right_click_object_tree)
         else:
             # tree_editor context menu binding (3rd mouse button for linux and windows)
-            self.tree_editor.treeview.bind("<3>", self.on_right_click_object_tree)        
+            self.tree_editor.treeview.bind('<3>', self.on_right_click_object_tree)        
 
         #
         # Application Keyboard bindings
@@ -668,10 +672,30 @@ class PygubuDesigner(object):
         elif itemid == 'help_about':
             self.show_about_dialog()
             
+    def evaluate_menu_states(self):
+        """
+        Check whether some menus (such as 'Duplicate' need to be enabled or disabled.
+        
+        The state of the menus is dependant on whether they can be used at the current time or not.
+        """
+        
+        menu_duplicate_context = self.builder.get_object('menu_duplicate')
+        menu_duplicate_edit = self.builder.get_object('TREE_ITEM_DUPLICATE')
+        
+        # Should we enable the 'Duplicate' menu?
+        self.duplicate_menu_state = 'disabled' if self.tree_editor.selection_different_parents() else 'normal'
+        menu_duplicate_context.entryconfig('Duplicate', state=self.duplicate_menu_state)
+        menu_duplicate_edit.entryconfig('Duplicate', state=self.duplicate_menu_state)
+                
+    def show_context_menu(self, event):
+        """
+        Show the context menu.
+        """
+        self.context_menu.tk_popup(event.x_root, event.y_root)
+
     # Right-click menu (on object tree)
     def on_right_click_object_tree(self, event):
-        # Show the context menu
-        self.context_menu.tk_popup(event.x_root, event.y_root)
+        self.show_context_menu(event)
 
     def on_context_menu_cut_clicked(self):
         """

--- a/pygubudesigner/main.py
+++ b/pygubudesigner/main.py
@@ -684,8 +684,8 @@ class PygubuDesigner(object):
         
         # Should we enable the 'Duplicate' menu?
         self.duplicate_menu_state = 'disabled' if self.tree_editor.selection_different_parents() else 'normal'
-        menu_duplicate_context.entryconfig('Duplicate', state=self.duplicate_menu_state)
-        menu_duplicate_edit.entryconfig('Duplicate', state=self.duplicate_menu_state)
+        menu_duplicate_context.entryconfig(5, state=self.duplicate_menu_state)
+        menu_duplicate_edit.entryconfig(3, state=self.duplicate_menu_state)
                 
     def show_context_menu(self, event):
         """

--- a/pygubudesigner/previewer.py
+++ b/pygubudesigner/previewer.py
@@ -23,6 +23,7 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 from collections import OrderedDict
+from functools import partial
 
 try:
     import tkinter as tk
@@ -477,8 +478,9 @@ class DialogPreview(ToplevelPreview):
 class PreviewHelper:
     indicators_tag = ('nw', 'ne', 'sw', 'se')
 
-    def __init__(self, canvas):
+    def __init__(self, canvas, app):
         self.canvas = canvas
+        self.app = app # so we can access the main GUI when needed (ie: the context menu)
         self.previews = OrderedDict()
         self.padding = 20
         self.indicators = None
@@ -731,5 +733,36 @@ class PreviewHelper:
 
     def bind_preview_widget(self, widget, callback):
         widget.bind('<Button-1>', callback)
+        
+        # The function that will be called when a right-click occurs.
+        # The second argument (callback) is used to select the widget before showing the context menu.
+        right_click_func = partial(self.on_right_clicked_preview_widget, callback)
+        
+        # For right-clicking - bind to button2 for macos and button3 for a different OS.
+        if sys.platform == 'darwin':
+            widget.bind('<Button-2>', right_click_func)
+        else:
+            widget.bind('<Button-3>', right_click_func)
+            
         for w in widget.winfo_children():
             self.bind_preview_widget(w, callback)
+
+    def on_right_clicked_preview_widget(self, callback, event):
+        """
+        A widget in the preview canvas has been right-clicked.
+        
+        Arguments:
+        
+        - Callback: we need to run this method before we show the context menu.
+        This method will cause the widget to be selected.
+        
+        - Event: a normal event argument. This will tell us which widget was right-clicked
+        on if we ever need that info.
+        """
+        
+        # Select the widget that was right-clicked.
+        callback(event)
+        
+        # Show the right-click context menu.
+        self.app.show_context_menu(event)
+        

--- a/pygubudesigner/ui/pygubu-ui.ui
+++ b/pygubudesigner/ui/pygubu-ui.ui
@@ -1152,12 +1152,6 @@
   <object class="tk.Menu" id="context_menu">
     <property name="tearoff">false</property>
     <child>
-      <object class="tk.Menuitem.Command" id="menu_cut">
-        <property name="command" type="command" cbtype="simple">on_context_menu_cut_clicked</property>
-        <property name="label" translatable="yes">Cut</property>
-      </object>
-    </child>
-    <child>
       <object class="tk.Menuitem.Command" id="menu_copy">
         <property name="command" type="command" cbtype="simple">on_context_menu_copy_clicked</property>
         <property name="label" translatable="yes">Copy</property>
@@ -1167,6 +1161,12 @@
       <object class="tk.Menuitem.Command" id="menu_paste">
         <property name="command" type="command" cbtype="simple">on_context_menu_paste_clicked</property>
         <property name="label" translatable="yes">Paste</property>
+      </object>
+    </child>
+    <child>
+      <object class="tk.Menuitem.Command" id="menu_cut">
+        <property name="command" type="command" cbtype="simple">on_context_menu_cut_clicked</property>
+        <property name="label" translatable="yes">Cut</property>
       </object>
     </child>
     <child>


### PR DESCRIPTION
1. Added a context menu for widgets in design view.
You can now copy, paste, cut, delete, duplicate a widget by right-clicking on a widget.
Closes #20 
![context_menu_designer](https://user-images.githubusercontent.com/45316730/132586126-7f08c7f2-171b-4337-85b9-b35da965a4bd.png)


2. In the object treeview, the 'Duplicate' option will now be disabled if the user has multiple widgets selected that don't all have the same parent. Duplicating multiple widgets with different parents will cause the duplicated widgets to have the same parent, which can be confusing for the user. So now the Duplicate menu will be disabled if the selected widgets don't all have the same parent.
![disable_duplicate_menu](https://user-images.githubusercontent.com/45316730/132586181-b0ac4795-0b80-4f5b-8a09-b16f8546a0fa.png)


3. The context menu order has been rearranged to match the Edit menu.
For example, the context menu order used to be: Cut, Copy, Paste, Delete, Duplicate.
Now it's: Copy, Paste, Cut, Delete, Duplicate.

There are two reasons for this change:
-  Consistency with the Edit menu
-  If 'Cut' were to be the first option, the user might accidentally click on it. This may become a problem because there is currently no undo option. It's safer to have 'Copy' as the first option.
![menu_order](https://user-images.githubusercontent.com/45316730/132586216-7def690b-c429-4bb1-bdc6-9480ec2fe899.png)
