### PR TITLE
Improve grid row/col options tracking.

### DIFF
--- a/pygubudesigner/codebuilder.py
+++ b/pygubudesigner/codebuilder.py
@@ -251,8 +251,8 @@ class UI2Code(Builder):
                     self._unique_grid_properties.append(l)
             
             # Remove duplicate lines that we already have (such as for example: self.frame1.columnconfigure(0, weight='1'))
-            for remove_idx in idx_to_remove:
-                layout.pop(remove_idx)
+            layout = [item for idx, item in enumerate(layout)
+                      if idx not in idx_to_remove]
             
             self._code.extend(layout)
 

--- a/pygubudesigner/codebuilder.py
+++ b/pygubudesigner/codebuilder.py
@@ -52,7 +52,7 @@ class UI2Code(Builder):
         self._callbacks = {}
         self._import_ttk = True
         self._code = []
-        self._unique_layout = []
+        self._unique_grid_properties = [] # Used for preventing duplicate grid row/column configure lines from ending up in the generated code.
         self.uidefinition = None
         self._builder = Builder()
         self._options = {}
@@ -237,13 +237,20 @@ class UI2Code(Builder):
             # layout
             layout = builder.code_layout(parentid=masterid)
 
+            # Prevent duplicate grid properties from making it to the final generated code.
+            
+            # For example: there may be 2 widgets that have a grid column weight of 1. The generated code
+            # will make the parent's columnconfigure property to weight='1', but it'll do it two times (once for each widget).
+            # The code below will prevent it from having the same grid configuration code generated twice.
             idx_to_remove = []
             for idx, l in enumerate(layout):
-                if l in self._unique_layout:
+                # Do we already have the property added to the code? If so, record the index so we can remove the duplicate line.
+                if l in self._unique_grid_properties:
                     idx_to_remove.append(idx)
                 else:
-                    self._unique_layout.append(l)
+                    self._unique_grid_properties.append(l)
             
+            # Remove duplicate lines that we already have (such as for example: self.frame1.columnconfigure(0, weight='1'))
             for remove_idx in idx_to_remove:
                 layout.pop(remove_idx)
             

--- a/pygubudesigner/codebuilder.py
+++ b/pygubudesigner/codebuilder.py
@@ -52,6 +52,7 @@ class UI2Code(Builder):
         self._callbacks = {}
         self._import_ttk = True
         self._code = []
+        self._unique_layout = []
         self.uidefinition = None
         self._builder = Builder()
         self._options = {}
@@ -235,6 +236,17 @@ class UI2Code(Builder):
 
             # layout
             layout = builder.code_layout(parentid=masterid)
+
+            idx_to_remove = []
+            for idx, l in enumerate(layout):
+                if l in self._unique_layout:
+                    idx_to_remove.append(idx)
+                else:
+                    self._unique_layout.append(l)
+            
+            for remove_idx in idx_to_remove:
+                layout.pop(remove_idx)
+            
             self._code.extend(layout)
 
             # callbacks

--- a/pygubudesigner/layouteditor.py
+++ b/pygubudesigner/layouteditor.py
@@ -247,6 +247,12 @@ class LayoutEditor(PropertiesEditor):
         value = editor.value
         if name in properties.MANAGER_PROPERTIES:
             self._current.layout_property(name, value)
+            
+            # If the row or column is being changed, removed the unused grid settings (such as weight)
+            # that no longer apply to the new row or column. Then refresh the properties view to reflect the new row/col.
+            if name in ('row', 'column'):
+                self._current.remove_unused_grid_rc()
+                editor.event_generate('<<RefreshPropertiesView>>')
         else:
             # asume that is a grid row/col property
             rowcol, pname = self.identify_gridrc_property(name)

--- a/pygubudesigner/layouteditor.py
+++ b/pygubudesigner/layouteditor.py
@@ -252,7 +252,7 @@ class LayoutEditor(PropertiesEditor):
             # that no longer apply to the new row or column. Then refresh the properties view to reflect the new row/col.
             if name in ('row', 'column'):
                 self._current.remove_unused_grid_rc()
-                editor.event_generate('<<RefreshPropertiesView>>')
+                editor.event_generate('<<RefreshLayoutPropertiesView>>')
         else:
             # asume that is a grid row/col property
             rowcol, pname = self.identify_gridrc_property(name)

--- a/pygubudesigner/layouteditor.py
+++ b/pygubudesigner/layouteditor.py
@@ -249,7 +249,7 @@ class LayoutEditor(PropertiesEditor):
             self._current.layout_property(name, value)
 
             # If the row or column has changed, remove the unused grid settings (such as weight)
-            # that no longer apply to the new row or column. Then refresh the properties view to reflect the new row/col.
+            # that no longer apply to the new row or column. Then refresh the properties layout view to reflect the new row/col.
             if name in ('row', 'column'):
                 self._current.remove_unused_grid_rc()
                 editor.event_generate('<<RefreshLayoutPropertiesView>>')

--- a/pygubudesigner/layouteditor.py
+++ b/pygubudesigner/layouteditor.py
@@ -247,8 +247,8 @@ class LayoutEditor(PropertiesEditor):
         value = editor.value
         if name in properties.MANAGER_PROPERTIES:
             self._current.layout_property(name, value)
-            
-            # If the row or column is being changed, removed the unused grid settings (such as weight)
+
+            # If the row or column has changed, remove the unused grid settings (such as weight)
             # that no longer apply to the new row or column. Then refresh the properties view to reflect the new row/col.
             if name in ('row', 'column'):
                 self._current.remove_unused_grid_rc()

--- a/pygubudesigner/layouteditor.py
+++ b/pygubudesigner/layouteditor.py
@@ -246,13 +246,16 @@ class LayoutEditor(PropertiesEditor):
     def _on_property_changed(self, name, editor):
         value = editor.value
         if name in properties.MANAGER_PROPERTIES:
-            self._current.layout_property(name, value)
-
+            
+            # Save new value and update the preview
+            self._current.layout_property(name, value)            
+            
             # If the row or column has changed, remove the unused grid settings (such as weight)
             # that no longer apply to the new row or column. Then refresh the properties layout view to reflect the new row/col.
             if name in ('row', 'column'):
                 self._current.remove_unused_grid_rc()
-                editor.event_generate('<<RefreshLayoutPropertiesView>>')
+                editor.event_generate('<<RefreshLayoutPropertiesView>>')      
+
         else:
             # asume that is a grid row/col property
             rowcol, pname = self.identify_gridrc_property(name)
@@ -262,6 +265,9 @@ class LayoutEditor(PropertiesEditor):
             target = self._current
             target.gridrc_property(rowcol, number, pname, value)
             editor.event_generate('<<LayoutEditorGridRCChanged>>')
+            
+            # Update the preview now, after the grid rc changes have been made.
+            target.notify('LAYOUT_GRIDRC_CHANGED', target)
 
     def identify_gridrc_property(self, alias):
         return alias.split('_')

--- a/pygubudesigner/main.py
+++ b/pygubudesigner/main.py
@@ -209,7 +209,7 @@ class PygubuDesigner(object):
 
         # Preview
         previewc = self.builder.get_object('preview_canvas')
-        self.previewer = PreviewHelper(previewc, self)
+        self.previewer = PreviewHelper(previewc, self.show_context_menu)
 
         # tree editor
         self.tree_editor = WidgetsTreeEditor(self)

--- a/pygubudesigner/previewer.py
+++ b/pygubudesigner/previewer.py
@@ -478,9 +478,9 @@ class DialogPreview(ToplevelPreview):
 class PreviewHelper:
     indicators_tag = ('nw', 'ne', 'sw', 'se')
 
-    def __init__(self, canvas, app):
+    def __init__(self, canvas, context_menu_method):
         self.canvas = canvas
-        self.app = app # so we can access the main GUI when needed (ie: the context menu)
+        self.show_context_menu = context_menu_method # The method we will call to show the context menu
         self.previews = OrderedDict()
         self.padding = 20
         self.indicators = None
@@ -764,5 +764,5 @@ class PreviewHelper:
         callback(event)
         
         # Show the right-click context menu.
-        self.app.show_context_menu(event)
+        self.show_context_menu(event)
         

--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -105,7 +105,7 @@ class WidgetsTreeEditor(object):
         self.treeview.bind_all(
             '<<PreviewItemSelected>>',
             self._on_preview_item_clicked)
-        self.treeview.bind_all('<<RefreshPropertiesView>>', self.refresh_properties)
+        self.treeview.bind_all('<<RefreshLayoutPropertiesView>>', self.refresh_layout_properties)
         # Listen to Grid RC changes from layout
         lframe.bind_all(
             '<<LayoutEditorGridRCChanged>>',
@@ -790,7 +790,7 @@ class WidgetsTreeEditor(object):
 
         # Make sure the selected widget has the same layout properties (weight, uniform, etc.)
         # as its siblings (if any). Then show (refresh) the latest layout properties in the Object Properties pane.
-        self.refresh_properties(event=None, item=item)
+        self.refresh_layout_properties(event=None, item=item, editor_gui_refresh=False)
 
         # Do redraw
         self.draw_widget(item)
@@ -843,7 +843,7 @@ class WidgetsTreeEditor(object):
             
             # Make sure the widget has the same layout properties (weight, uniform, etc.)
             # as its siblings (if any). Then show (refresh) the latest layout properties in the Object Properties pane.
-            self.refresh_properties(event=None, item=pwidget)            
+            self.refresh_layout_properties(event=None, item=pwidget, editor_gui_refresh=False)            
             
             for mchild in uidef.widget_children(original_id):
                 self.populate_tree(pwidget, uidef, mchild, from_file=from_file)
@@ -861,7 +861,7 @@ class WidgetsTreeEditor(object):
                 max_row = row
         return max_row
     
-    def refresh_properties(self, event, item=None):
+    def refresh_layout_properties(self, event, item=None, editor_gui_refresh=True):
         """
         Copy sbiling properties (such as weight) and select the item in the treeview so the latest properties are shown.
         Used for grid.
@@ -871,6 +871,16 @@ class WidgetsTreeEditor(object):
         the same row or same column.
         
         For example: if its sibling has a grid column weight of 1, this item will also end up having a column weight of 1.
+        
+        Arguments:
+        
+        - event: this is a regular tk Event which will contain Event data if this method is run via event_generate().
+        
+        - item: the caller of this method may pass in the treeview item here. Otherwise, we'll use the selected treeview item.
+        
+        - editor_gui_refresh: specify whether we should reload/refresh the Object Properties pane GUI (Layout tab).
+        Some callers of this method will update the Object Properties pane on their own, while others may not (hence the use of this flag).
+        The reason this argument is here is to prevent multiple refreshes of the Object Properties pane.
         """
 
         # Set the widget's row/column properties (such as weight) to be 
@@ -914,7 +924,8 @@ class WidgetsTreeEditor(object):
                     break
         
         # Show the new properties of the widget in the object properties pane (this refreshes the Layout tab).
-        self.editor_edit(current_item, self.treedata[current_item])
+        if editor_gui_refresh:
+            self.editor_edit(current_item, self.treedata[current_item])
 
     def on_treeview_select(self, event):
         tree = self.treeview

--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -105,7 +105,7 @@ class WidgetsTreeEditor(object):
         self.treeview.bind_all(
             '<<PreviewItemSelected>>',
             self._on_preview_item_clicked)
-        self.treeview.bind_all('<<RefreshLayoutPropertiesView>>', self.refresh_layout_properties)
+        self.treeview.bind_all('<<RefreshLayoutPropertiesView>>', self.synchronize_layout_properties)
         # Listen to Grid RC changes from layout
         lframe.bind_all(
             '<<LayoutEditorGridRCChanged>>',
@@ -789,8 +789,8 @@ class WidgetsTreeEditor(object):
         item = self._insert_item(root, data)
 
         # Make sure the selected widget has the same layout properties (weight, uniform, etc.)
-        # as its siblings (if any). Then show (refresh) the latest layout properties in the Object Properties pane.
-        self.refresh_layout_properties(event=None, item=item, editor_gui_refresh=False)
+        # as its siblings (if any).
+        self.synchronize_layout_properties(event=None, item=item, editor_gui_refresh=False)
 
         # Do redraw
         self.draw_widget(item)
@@ -843,7 +843,7 @@ class WidgetsTreeEditor(object):
             
             # Make sure the widget has the same layout properties (weight, uniform, etc.)
             # as its siblings (if any). Then show (refresh) the latest layout properties in the Object Properties pane.
-            self.refresh_layout_properties(event=None, item=pwidget, editor_gui_refresh=False)            
+            self.synchronize_layout_properties(event=None, item=pwidget, editor_gui_refresh=False)            
             
             for mchild in uidef.widget_children(original_id):
                 self.populate_tree(pwidget, uidef, mchild, from_file=from_file)
@@ -861,9 +861,9 @@ class WidgetsTreeEditor(object):
                 max_row = row
         return max_row
     
-    def refresh_layout_properties(self, event, item=None, editor_gui_refresh=True):
+    def synchronize_layout_properties(self, event, item=None, editor_gui_refresh=True):
         """
-        Copy sbiling properties (such as weight) and select the item in the treeview so the latest properties are shown.
+        Copy sibling properties (such as weight) and select the item in the treeview so the latest properties are shown.
         Used for grid.
         
         This was made so that when the grid row/column is changed, the options in the 'Layout' tab also 

--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -368,7 +368,6 @@ class WidgetsTreeEditor(object):
             widget_id = self.treedata[item].identifier
             wclass = self.treedata[item].classname
             uidef = self.tree_to_uidef(item)
-
             self.previewer.draw(item, widget_id, uidef, wclass)
             self.previewer.show_selected(item, selected_id)
             self.filter_restore()

--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -909,7 +909,7 @@ class WidgetsTreeEditor(object):
                 wu = self.treedata[child]
                 wu_row = wu.layout_property('row')
                 wu_col = wu.layout_property('column')
-                
+
                 # Is this sibling widget on the same row as our widget? Copy its row properties.
                 if wu_row == srow:
                     wmeta.copy_gridrc(wu, 'row')
@@ -1074,6 +1074,7 @@ class WidgetsTreeEditor(object):
     def on_item_grid_move(self, direction):
         tree = self.treeview
         selection = tree.selection()
+        using_grid = True
         if selection:
             item_first = selection[0]
             self.filter_remove(remember=True)
@@ -1081,6 +1082,7 @@ class WidgetsTreeEditor(object):
                 data = self.treedata[item]
 
                 if data.manager != 'grid':
+                    using_grid = False
                     break
 
                 if direction == self.GRID_UP:
@@ -1108,7 +1110,8 @@ class WidgetsTreeEditor(object):
                 root = tree.parent(item)
                 data.remove_unused_grid_rc()
             self.filter_restore()
-            self.synchronize_layout_properties(event=None, item=item_first)
+            if using_grid:
+                self.synchronize_layout_properties(event=None, item=item_first)
 
     #
     # Filter functions

--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -503,10 +503,10 @@ class WidgetsTreeEditor(object):
             if data.manager == 'grid':
                 row = data.layout_property('row')
                 col = data.layout_property('column')
-                # fix row position when using copy and paste
-                # If collision, increase by 1
+                # Fix grid row position when using copy and paste
+                # Increase the pasted widget by 1 row so that it doesn't overlap
                 row_count = self.get_max_row(root)
-                if not from_file and (row_count > int(row) and int(col) == 0):
+                if not from_file:
                     row = str(row_count + 1)
                     data.layout_property('row', row)
 

--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -105,6 +105,7 @@ class WidgetsTreeEditor(object):
         self.treeview.bind_all(
             '<<PreviewItemSelected>>',
             self._on_preview_item_clicked)
+        self.treeview.bind_all('<<RefreshPropertiesView>>', self.refresh_properties)
         # Listen to Grid RC changes from layout
         lframe.bind_all(
             '<<LayoutEditorGridRCChanged>>',
@@ -850,6 +851,20 @@ class WidgetsTreeEditor(object):
             if row > max_row:
                 max_row = row
         return max_row
+    
+    def refresh_properties(self, event):
+        """
+        Refresh the object properties pane for the selected item.
+        
+        This was made so that when the grid row/column is changed, the option labelframes
+        in the 'Layout' tab also reflect the changed row/column.
+        """
+        tree = self.treeview
+        sel = tree.selection()
+        if sel:
+            item = sel[0]
+            self.editor_edit(item, self.treedata[item])
+      
 
     def on_treeview_select(self, event):
         tree = self.treeview

--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -842,7 +842,7 @@ class WidgetsTreeEditor(object):
             pwidget = self._insert_item(master, wmeta, from_file=from_file)
             
             # Make sure the widget has the same layout properties (weight, uniform, etc.)
-            # as its siblings (if any). Then show (refresh) the latest layout properties in the Object Properties pane.
+            # as its siblings (if any).
             self.synchronize_layout_properties(event=None, item=pwidget, editor_gui_refresh=False)            
             
             for mchild in uidef.widget_children(original_id):
@@ -895,11 +895,13 @@ class WidgetsTreeEditor(object):
         parent = self.treeview.parent(current_item)
         wmeta = self.treedata[current_item]
         srow = wmeta.layout_property('row')
-        scol = wmeta.layout_property('column')        
+        scol = wmeta.layout_property('column')    
+        
         if parent:
-            copied_row_property = False
-            copied_column_property = False
             children = self.treeview.get_children(parent)
+            copied_row_property = False
+            copied_column_property = False 
+            
             for child in children:
                 if child == current_item:
                     continue
@@ -922,7 +924,7 @@ class WidgetsTreeEditor(object):
                 # there is no need to check other sibling widgets, so exit the loop.
                 if copied_row_property and copied_column_property:
                     break
-        
+
         # Show the new properties of the widget in the object properties pane (this refreshes the Layout tab).
         if editor_gui_refresh:
             self.editor_edit(current_item, self.treedata[current_item])
@@ -1104,8 +1106,9 @@ class WidgetsTreeEditor(object):
                     data.layout_property('column', str(column))
                     data.notify()
                 root = tree.parent(item)
+                data.remove_unused_grid_rc()
             self.filter_restore()
-            self.editor_edit(item_first, self.treedata[item_first])
+            self.synchronize_layout_properties(event=None, item=item_first)
 
     #
     # Filter functions

--- a/pygubudesigner/widgetdescr.py
+++ b/pygubudesigner/widgetdescr.py
@@ -112,8 +112,26 @@ class WidgetMeta(WidgetMetaBase, Observable):
         self.bindings.append(BindingMeta(seq, handler, add))
 
     def remove_unused_grid_rc(self):
-        """Deletes unused grid row/cols"""
-        pass
+        """Deletes unused grid row/col options (such as weight)"""
+
+        # in self.gridrc_properties, a line will look something like this:
+        # GridRCLine(rctype='row', rcid='3', pname='weight', pvalue='6')
+        # That means that row #3 has a weight of 6.
+        
+        # Based on the example above, we would get the widget's current row and column and
+        # remove any references to rows/columns options that don't match this widget's current row/column.
+            
+        # Get the widget's current row and column.
+        current_row = self.layout_properties.get("row")
+        current_column = self.layout_properties.get("column")
+        
+        # Only keep the gridrc properties that match the widget's row and column.
+        filtered_list = [line for line in self.gridrc_properties
+                         if (line.rctype == "row" and line.rcid == current_row)
+                         or (line.rctype == "col" and line.rcid == current_column)]
+        
+        # The new filtered list.
+        self.gridrc_properties = filtered_list
 
     def setup_defaults(self):
         propd, layoutd = WidgetMeta.get_widget_defaults(self, self.identifier)

--- a/pygubudesigner/widgetdescr.py
+++ b/pygubudesigner/widgetdescr.py
@@ -86,7 +86,6 @@ class WidgetMeta(WidgetMetaBase, Observable):
         else:
             # Setter
             self.set_gridrc_value(type_, num, pname, value)
-            self.notify('LAYOUT_GRIDRC_CHANGED', self)
 
     @property
     def manager(self):


### PR DESCRIPTION
This pull request consists of improvements and bug fixes - both mostly related to grid rc properties (such as row/col weight).

1. When changing the grid row or column, it now shows the new grid row/column in the properties section.
Before, it would not update.
![rc_shows_changes](https://user-images.githubusercontent.com/45316730/134270106-5e652458-20ed-4dfc-8a0b-ca47f48a5b0f.png)

2. When changing the grid row or column, it will now clean up any unused grid row/column properties, such as weight.
For example: let's say you are editing a widget on row 0 with a weight of 1. If you change the row number to 1, it will now reset
the weight to 0. Before, it didn't use to reset the old row/column properties; it kept the old property info and it showed up in the generated code even though it was never used.
![generate_most_recent_configuration](https://user-images.githubusercontent.com/45316730/134270222-563acfa3-b607-4ea1-90ad-22b3af2a240e.png)


3. Bug fix: Prevent duplicate grid properties from showing up in generated code. This is also related to settings such as grid weight.
For example: if you have:

> frame1
>  -> button1 (column=0, weight=1)
>  -> button2 (column=0, weight=1)

Then Pygubu would generate the following line, twice:
self.frame1.columnconfigure(0, weight='1') 
self.frame1.columnconfigure(0, weight='1')

Because there are 2 widgets with the same weight. Now with this pull request, duplicate lines like the one above are prevented from showing up in the generated code. 

It will only show up one time:
> self.frame1.columnconfigure(0, weight='1') 

![no_duplicate_code](https://user-images.githubusercontent.com/45316730/134270352-dda4726b-1550-49f0-8c1b-2e20bb844e44.png)

4. Bug fix: Before when pasting or duplicating a widget that uses grid, the pasted item would end up having the same grid row/column as the original widget, and it would overlap. This would make it seem like pasting or duplicating never worked, but in fact the new widget was on top of the old widget.
Now with this pull request, pasting or duplicating a widget that is using grid will increase the row by 1 automatically. It was supposed to do this before apparently, but the code didn't seem to work right.
So this pull request fixes it.

5. Bug fix: when widget rows/columns were changed using Edit -> Widget grid (or the shortcut keys), the widget row/col properties (such as weight) would not change to reflect the new row or column that it was moved to. Now the Layout tab in the designer will show/update the widgets' row/col options if the row/col changes.

6. When a new widget is added (or pasted or duplicated), before it would not show the shared grid row/column properties that already exist.
For example, before if we had a widget at column 0 with a weight of 1, and you added a new widget to column 0, the properties pane would not show a weight of 1. It would show a weight of 0.
Now, it shows the correct properties based on the widgets' siblings.

7. Fixed a bug where the preview canvas sometimes refreshes too soon when grid rc property changes are made (such as changing the weight). Depending on the UI, this sometimes caused the preview canvas to not show the latest preview. However, in cases like this, the generated code was still correct - it only affected the preview canvas.
Now, with this pull request, the preview canvas is updated *after* all the grid rc changes have been made.

Here is a real example screenshot of what the problem looked like:
![preview_not_matching](https://user-images.githubusercontent.com/45316730/134739668-a89eeeb0-4dd0-4f99-8de3-115e5b11722d.png)


8. Pass the 'show_context_menu' method to PreviewHelper instead of the app object.
It makes it easier to understand what's happening. This is a small change.