### PR TITLE
Show only supported 'selectmode' parameter values for EditableTreeview.

### DIFF
--- a/pygubudesigner/properties.py
+++ b/pygubudesigner/properties.py
@@ -806,7 +806,13 @@ TK_WIDGET_OPTIONS = {
                 'values': (tk.EXTENDED, tk.BROWSE, tk.NONE),
                 'state': 'readonly'},
             'default': tk.EXTENDED,
-        }
+        },
+        'pygubu.builder.widgets.editabletreeview': {
+            'params': {
+                'values': (tk.EXTENDED, tk.BROWSE, tk.NONE),
+                'state': 'readonly'},
+            'default': tk.EXTENDED,
+        }        
     },
     'setgrid': {
         'editor': 'dynamic',


### PR DESCRIPTION
Bug fix: the 'selectmode' parameter values for **EditableTreeview** contains 2 extra selectmodes that are not supported by EditableTreeview - **single, multiple**. Selecting 'single' or 'multiple' will raise an error. This pull request causes the 'selectmode' parameter to only show the supported values, which are: none, browse, extended.
![before](https://user-images.githubusercontent.com/45316730/137056668-db5945a4-ce83-4b06-91e5-0932de677744.png)



![after](https://user-images.githubusercontent.com/45316730/137056679-c6fe2c34-7acd-49a3-a423-14b7a6e09642.png)

