### PR TITLE
Pasting bug fixes + enhancements

### DIFF
--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -953,9 +953,9 @@ class WidgetsTreeEditor(object):
                 sibling_row = sibling_properties.layout_property('row')
                 sibling_col = sibling_properties.layout_property('column')
                 
-                # Keep track of the max row number, because we may need to use it
-                # after the loop is done.
-                if int(sibling_row) > max_row:
+                # Keep track of the max row number in the new item's column, 
+                # because we may need to use it after the loop is done.
+                if sibling_col == new_item_column and int(sibling_row) > max_row:
                     max_row = int(sibling_row)            
                 
                 # If the item that is being pasted (the new item) has the same


### PR DESCRIPTION
### 1. Bug fix when pasting items that use Grid:

**Problem**: Pasting or duplicating widget(s) increased the row number of the widgets' children by 1,
instead of only increasing the row for the first (parent) widget. 

This bug was caused by the last change which automatically increased pasted or duplicate widgets row numbers by 1.

**Solution**: Now it does more detailed checks to decide if it should increase the row number or not.

**Solution Details**:
- If the pasted widget has children, none of the children's row numbers will change.
Only the parent's widget (most outer pasted widgets) will increase row by 1, if required.

- If a sibling widget has the same row AND column as the pasted widget(s), 
it will increase the pasted widget(s) row number by 1.

- If there is no conflict with the newly pasted widgets' row/column, the row will
not be changed.


![1 paste_before](https://user-images.githubusercontent.com/45316730/137567064-30b40f24-65c9-4c2f-b154-624105e2af85.png)

![1 paste_after](https://user-images.githubusercontent.com/45316730/137567143-7a22c8fa-edb9-42ee-b34d-645868dcec55.png)

### 2. Bug fix when deleting items:

**Problem**: Deleting items from the treeview did not delete the data of the items' children in self.treedata (Dict).
It only deleted the parent item's data.

**How to reproduce the problem:**
This would cause a problem in this scenario:
Let's say you copied 'button1' to the clipboard from this setup:
frame1 (parent)
  -> button1 (child)
  
1. Delete frame1 (this will delete button1 from the treeview, but not from the treedata dictionary)
2. Add a new frame, but don't make a button.
3. Paste button1 from the clipboard into the new frame that you just added.
4. Click on button1 in the designer. You will get an exception, because self.treedata
still has a reference to the button's old item iid (which no longer exists in the treeview).

**Solution**:
With this pull request, deleting a widget will now also delete all its descendants from the treedata dictionary.

![2 delete_before](https://user-images.githubusercontent.com/45316730/137567176-e23d176b-b00e-40d3-b666-fb6001995d2a.png)

![2 delete_after](https://user-images.githubusercontent.com/45316730/137567177-3565fda5-cc46-4fa3-a6f8-5e75b7eb82d8.png)

### 3. Enhancement: when pasting widgets that use grid:
If the row number needs to increase, get the max row for the pasted widget only, not the overall max row.
![3 row_before](https://user-images.githubusercontent.com/45316730/137567211-0487fd45-b9a3-412c-8a1a-6d3e331410c1.png)


![3 row_after](https://user-images.githubusercontent.com/45316730/137567336-fa3f7200-5179-4509-854f-d7922746aff9.png)


