### PR TITLE
Fix bug: setting the weight of a widget to a blank string causes an error.

### DIFF
--- a/pygubudesigner/properties.py
+++ b/pygubudesigner/properties.py
@@ -1554,6 +1554,7 @@ LAYOUT_OPTIONS = {
     },
     'weight': {
         'editor': 'naturalnumber',
+        'params': {'empty_data': 0},
         'help': help_for('weight-grid')
     },
     'uniform': {

--- a/pygubudesigner/widgets/dimensionentry.py
+++ b/pygubudesigner/widgets/dimensionentry.py
@@ -40,7 +40,6 @@ class DimensionPropertyEditor(EntryPropertyEditor):
     REGEX = RE_DIMENSION
 
     def __init__(self, master=None, **kw):
-        self._empty_data = None
         EntryPropertyEditor.__init__(self, master, **kw)
 
     def _validate(self):
@@ -51,20 +50,6 @@ class DimensionPropertyEditor(EntryPropertyEditor):
             valid = True
         self.show_invalid(not valid)
         return valid
-
-    def _get_value(self):
-        value = self._variable.get()
-
-        if self._empty_data is not None and value == '':
-            value = str(self._empty_data)
-            self._set_value(value)
-
-        return value
-
-    def parameters(self, **kw):
-        pvalue = kw.pop('empty_data', None)
-        self._empty_data = None if pvalue is None else pvalue
-        EntryPropertyEditor.parameters(self, **kw)
 
 
 class TwoDimensionPropertyEditor(DimensionPropertyEditor):

--- a/pygubudesigner/widgets/propertyeditor.py
+++ b/pygubudesigner/widgets/propertyeditor.py
@@ -118,6 +118,7 @@ class PropertyEditor(ttk.Frame):
 
 class EntryPropertyEditor(PropertyEditor):
     def _create_ui(self):
+        self._empty_data = None
         self._entry = entry = ttk.Entry(self, textvariable=self._variable)
         entry.grid(sticky='we')
         self.rowconfigure(0, weight=1)
@@ -126,7 +127,18 @@ class EntryPropertyEditor(PropertyEditor):
         entry.bind('<KeyPress>', self._on_keypress)
 
     def parameters(self, **kw):
+        pvalue = kw.pop('empty_data', None)
+        self._empty_data = None if pvalue is None else pvalue
         self._entry.configure(**kw)
+        
+    def _get_value(self):
+        value = self._variable.get()
+
+        if self._empty_data is not None and value == '':
+            value = str(self._empty_data)
+            self._set_value(value)
+
+        return value    
 
 
 class AlphanumericEntryPropertyEditor(EntryPropertyEditor):
@@ -265,7 +277,7 @@ class NaturalNumberEditor(EntryPropertyEditor):
                 pass
         self.show_invalid(not valid)
         return valid
-
+    
 
 class IntegerNumberEditor(EntryPropertyEditor):
     def _validate(self):


### PR DESCRIPTION
### Fix bug: when the weight of a widget tries to be set to a blank string it causes an error.

**Problem**: deleting the value of a widget's weight (so it ends up with a blank string) causes an error because it's expecting a number.

**Solution**: There is a parameter called _empty_data_, which is currently only supported by the DimensionPropertyEditor class.

With this pull request, the empty_data parameter support has been moved to the EntryPropertyEditor class so that the NaturalNumberEditor class can take advantage of it too ('weight' uses NaturalNumberEditor).

DimensionPropertyEditor can still use the empty_data related variables too, because it inherits from EntryPropertyEditor. The empty_data value for 'weight' is set to 0. So now if the value of 'weight' is set to a blank string, it will default to 0 instead of raising an error.

![before_weight](https://user-images.githubusercontent.com/45316730/138523592-4cb2d37c-d84f-42c4-8231-b375fa01b119.png)
![after_weight](https://user-images.githubusercontent.com/45316730/138523600-7dbb1a57-4845-4038-9820-025422db5a0c.png)

