### PR TITLE
Refresh style combobox in the properties editor

### DIFF
--- a/pygubudesigner/propertieseditor.py
+++ b/pygubudesigner/propertieseditor.py
@@ -48,7 +48,12 @@ class PropertiesEditor(object):
         self._propbag = {}
         self._id_validator = kw.get('id_validator', None)
         self._create_properties()
-        self.style_handler = StyleHandler(self._sframe)
+        
+        # Used for refreshing/re-populating the styles combobox.
+        # Used when the style definition gets updated (simulates clicking on the treeview item again.)
+        reselect_item_func = kw.get('reselect_item_func', None) 
+        
+        self.style_handler = StyleHandler(self._sframe, reselect_item_func=reselect_item_func)
         self.style_handler.start_monitoring()
 
         self.hide_all()

--- a/pygubudesigner/stylehandler.py
+++ b/pygubudesigner/stylehandler.py
@@ -51,10 +51,14 @@ class StyleHandler:
     last_definition_file = None
     last_modified_time = None
 
-    def __init__(self, mframe):
+    def __init__(self, mframe, reselect_item_func):
         self.mframe = mframe
         self.after_token = None
         self.style = StyleRegister()
+        
+        # Used for refreshing/re-populating the styles combobox.
+        # Used when the style definition gets updated (simulates clicking on the treeview item.)        
+        self.reselect_item_func = reselect_item_func
 
     def start_monitoring(self):
         self.mframe.after_idle(self.check_definition_file)
@@ -110,5 +114,10 @@ class StyleHandler:
             StyleRegister.STYLE_DEFINITIONS.clear()
             
             self._apply_ttk_styles(contents)
+            
+            # Re-select the selected item so the style combobox
+            # will show the latest styles from the definition file.
+            self.reselect_item_func()
+        
         # schedule new check
         self.after_token = self.mframe.after(1000, self.check_definition_file)

--- a/pygubudesigner/stylehandler.py
+++ b/pygubudesigner/stylehandler.py
@@ -102,6 +102,13 @@ class StyleHandler:
             contents = None
             with open(style_definition_path) as f:
                 contents = f.read()
+                
+            # Clear and reload all the definitions.
+            
+            # Reason: so that definitions that are no longer in the definition file 
+            # will no longer populate in the style combobox.
+            StyleRegister.STYLE_DEFINITIONS.clear()
+            
             self._apply_ttk_styles(contents)
         # schedule new check
         self.after_token = self.mframe.after(1000, self.check_definition_file)

--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -20,6 +20,7 @@ import logging
 import os
 import xml.etree.ElementTree as ET
 from collections import Counter
+from functools import partial
 
 try:
     import tkinter as tk
@@ -97,9 +98,9 @@ class WidgetsTreeEditor(object):
         lframe = app.builder.get_object('layoutframe')
         bframe = app.builder.get_object('bindingsframe')
         bindingstree = app.builder.get_object('bindingstree')
-
         self.properties_editor = PropertiesEditor(
-            pframe, id_validator=self.is_id_unique)
+            pframe, id_validator=self.is_id_unique, 
+            reselect_item_func=partial(self.on_treeview_select, None))
         self.layout_editor = LayoutEditor(lframe)
         self.bindings_editor = BindingsEditor(bindingstree, bframe)
         self.treeview.bind_all(


### PR DESCRIPTION
Two pull requests:

The first pull request will prevent old styles (that have been since deleted from a definition file) from showing up in a style combobox. Before, it was always appending to a set but the set was not being cleared, so if the definition file has style1, style2, style3, but later the user decides to delete style3, the style combobox was still showing style1 and style2. Now it will clear the styles before loading them into the set again.

The second pull request is similar to the first one, except it applies to the currently selected widget. Before, when the definition file was reloaded, the user had to click on the widget again to see the latest styles in the style combobox (because the style combobox was not auto-updating. The user had to click on the widget again, or click away from the widget, then click back, to see the latest styles). This pull request will simulate clicking on the selected item when the definition file has been reloaded so that the currently selected item will reflect the latest style definition names.