### PR TITLE
Correct typo and suggest restart after removing a style definition.

### DIFF
--- a/pygubudesigner/codebuilder.py
+++ b/pygubudesigner/codebuilder.py
@@ -162,7 +162,7 @@ class UI2Code(Builder):
         """
         Generate the ttk style code.
         """
-        style_definition = StyleHandler.get_ttk_style_difinitions()
+        style_definition = StyleHandler.get_ttk_style_definitions()
 
         if not style_definition:
             return ''

--- a/pygubudesigner/preferences.py
+++ b/pygubudesigner/preferences.py
@@ -250,11 +250,21 @@ class PreferencesUI(object):
 
     def on_clicked_remove_style_file(self, widget_id):
         """
-        Clear a Ttk style definition or population file.
+        Clear a Ttk style definition.
         """
+        suggest_restart = False
+        
         if widget_id == 'btn_remove_style_definition':
             variable_to_set = self.v_style_definition_file
+            
+            # Is there an existing style definition path?
+            if self.v_style_definition_file.get():
+                suggest_restart = True
         variable_to_set.set('')
+        
+        if suggest_restart:
+            msg = _("Restart Pygubu Designer for\nchanges to take effect.")
+            messagebox.showinfo(_('Styles'), msg)            
 
     def on_dialog_close(self, event=None):
         self._save_options()

--- a/pygubudesigner/stylehandler.py
+++ b/pygubudesigner/stylehandler.py
@@ -75,7 +75,7 @@ class StyleHandler:
             logger.error(msg, e)
 
     @classmethod
-    def get_ttk_style_difinitions(cls):
+    def get_ttk_style_definitions(cls):
         contents = None
         style_definition_path = pref.get_option('v_style_definition_file')
 


### PR DESCRIPTION
1) Correct a method name typo
2) Preferences window: In a message box, suggest to the user to restart Pygubu Designer after removing a Ttk style definition (when the 'Remove' button is clicked).