### PR TITLE
Allow selected widget to change from place manager to pack or grid

### DIFF
--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -254,7 +254,8 @@ class WidgetsTreeEditor(object):
             for child in children:
                 widget = self.treedata[child]
                 # Don't change widgets with place manager
-                if widget.manager != 'place':
+                # unless the selected widget's manager is being changed.
+                if widget.manager != 'place' or child == item:
                     widget.manager = new_manager  # Change manager
 
                     # update Tree R/C columns


### PR DESCRIPTION
There is currently a bug where changing the selected widget's geometry manager from place to pack or grid will not change the  geometry manager for that widget, if it has siblings. The selected widget will stay with the place manager.

For example:

```
Frame1:
 -> Button1 (place) --The selected widget
 -> Button2 (grid)
 -> Button3 (grid)
 -> Button4 (place)
```
 
If I attempt to change Button1's manager from place to pack, it will ask me if I want to change the geometry manager for the other widgets too. If I say yes, it will change Button2 and Button3 to pack, but Button1 will stay with a place manager. It's expected for Button4 to stay with the place manager, but Button1 should change because it's selected.

Given the scenario above, this pull request will cause Button1 to change to the new geometry manager (because it's selected) while leaving Button4 with the place manager.