### PR TITLE
Prevent grid row/col from showing in treeview when widget is using pack or place

### DIFF
--- a/pygubudesigner/layouteditor.py
+++ b/pygubudesigner/layouteditor.py
@@ -177,6 +177,11 @@ class LayoutEditor(PropertiesEditor):
             self._current.manager = new_manager
             self.edit(self._current, self._allowed_managers)
 
+            # If we're moving away from grid, remove the row/col values
+            # in the treeview (so the user knows grid is not being used)
+            if old_manager == 'grid':
+                self._sframe.event_generate('<<ClearSelectedGridTreeInfo>>')
+
     def _ask_manager_change(self, old_manager, new_manager):
         title = _('Change Manager')
         msg = _('Change manager from {0} to {1}?')

--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -102,6 +102,7 @@ class WidgetsTreeEditor(object):
         lframe.bind_all('<<LayoutEditorContainerManagerToGrid>>', f)
         f = lambda e, manager='pack': self.change_container_manager(manager)
         lframe.bind_all('<<LayoutEditorContainerManagerToPack>>', f)
+        lframe.bind_all('<<ClearSelectedGridTreeInfo>>', self.clear_selected_grid_tree_info)
 
         # Tree Editing
         tree = self.treeview
@@ -134,6 +135,22 @@ class WidgetsTreeEditor(object):
 
             if do_delete:
                 self.on_treeview_delete_selection(None)
+
+    def clear_selected_grid_tree_info(self, event):
+        """
+        Clear the row/column text in the object treeview
+        for the selected item.
+
+        This gets called when the geometry manager of the
+        currently selected widget changes from grid to pack or to place.
+
+        This does not get used when multiple widgets need to have
+        their geometry managers changed inside a container widget.
+        """
+        if self.current_edit:
+            values = self.treeview.item(self.current_edit, 'values')
+            values = (values[0], '', '')
+            self.treeview.item(self.current_edit, values=values)
 
     def selection_different_parents(self):
         """


### PR DESCRIPTION
Fixes a bug:
When there is a widget without siblings and its geometry manager is set to 'grid', changing it to 'pack' or 'place', it will still show the grid row/col in the object treeview.

This pull request will clear the grid row/col from the object treeview (for that widget) when the geometry manager changes from grid to pack or grid, when the widget doesn't have any siblings.

Example:
![before](https://user-images.githubusercontent.com/45316730/157548630-d31a2b6d-862f-494b-90c9-4583f6bd3ac5.png)
![after](https://user-images.githubusercontent.com/45316730/157548655-cc57a8e7-bc81-4858-9828-4422c15f1714.png)


