### PR TITLE
Prevent resizable property of tk.Toplevel from setting the weight

### DIFF
--- a/pygubudesigner/widgets/toplevelframe.py
+++ b/pygubudesigner/widgets/toplevelframe.py
@@ -119,12 +119,6 @@ class ToplevelFramePreviewBO(BuilderObject):
                         tw.pack_propagate(0)
                     elif tw.grid_slaves():
                         tw.grid_propagate(0)
-        elif pname == 'resizable':
-            if value:
-                if value in ('both', 'horizontally'):
-                    tw.columnconfigure(0, weight=1)
-                if value in ('both', 'vertically'):
-                    tw.rowconfigure(0, weight=1)
         elif pname == 'modal':
             # Do nothing, fake 'modal' property for dialog preview
             pass


### PR DESCRIPTION
**Purpose of this pull request**
Prevent the resizable property of tk.Toplevel from setting the weight of the preview canvas.


**The problem**
If a toplevel (tk.Toplevel) is set to be 'resizable' = 'both' or 'horizontally' or 'vertically', the preview canvas will automatically set weight=1 for row=0 and/or column=0, 

This causes the preview canvas to show an inaccurate representation of the final design when the preview canvas gets resized with the mouse.

However, pressing F5 will not have this problem. F5 will show a "real" preview in regards to the 'resizable' property.

You can see this phenomena in the screenshot below:
![before_weight](https://user-images.githubusercontent.com/45316730/159083006-18248eb1-90dd-4f00-8b08-fca45d7738ee.png)

In other words, setting a toplevel to resizable='both' will set the weight of the toplevel widget in the preview canvas, which in my opinion it shouldn't do, because the preview canvas then won't resemble the true look of the final design.

The reason this is happening is below:

In the file, toplevelframe.py, this code is responsible for it:
https://github.com/alejandroautalan/pygubu-designer/blob/ee942789f731cb0d9b8bb996c359cbd9ffffed9e/pygubudesigner/widgets/toplevelframe.py#L125-L130

My question is: why was that code put there to begin with? I could find no reason for it.

If that code needs to be there for a reason, feel free to reject this pull request. Otherwise, it fixes the issue I've mentioned.

**The fix**
When I remove that block of code, the preview canvas accurately represents the F5 preview during my tests.

![after_weight](https://user-images.githubusercontent.com/45316730/159083072-d8d99c1a-f6fd-40c5-aec4-8e52ab0159a7.png)


Thanks,