### PR TITLE
Add a new context command menu to select the current item's parent.

### DIFF
--- a/pygubudesigner/main.py
+++ b/pygubudesigner/main.py
@@ -693,7 +693,7 @@ class PygubuDesigner(object):
 
         # Should we enable the 'Duplicate' menu?
         self.duplicate_menu_state = 'disabled' if self.tree_editor.selection_different_parents() else 'normal'
-        menu_duplicate_context.entryconfig(5, state=self.duplicate_menu_state)
+        menu_duplicate_context.entryconfig(7, state=self.duplicate_menu_state)
         menu_duplicate_edit.entryconfig(3, state=self.duplicate_menu_state)
 
     def show_context_menu(self, event):
@@ -705,6 +705,20 @@ class PygubuDesigner(object):
     # Right-click menu (on object tree)
     def on_right_click_object_tree(self, event):
         self.show_context_menu(event)
+        
+    def on_context_menu_go_to_parent_clicked(self):
+        """
+        Go to parent was clicked from the context menu.
+        
+        Select the parent of the currently selected widget.
+        """
+        current_selected_item = self.tree_editor.current_edit
+        if current_selected_item and self.treeview.exists(current_selected_item):
+            parent_iid = self.treeview.parent(current_selected_item)
+            
+            if parent_iid:
+                self.treeview.selection_set(parent_iid)
+                self.treeview.see(parent_iid)
 
     def on_context_menu_cut_clicked(self):
         """

--- a/pygubudesigner/ui/pygubu-ui.ui
+++ b/pygubudesigner/ui/pygubu-ui.ui
@@ -225,6 +225,15 @@
   <object class="tk.Menu" id="context_menu">
     <property name="tearoff">false</property>
     <child>
+      <object class="tk.Menuitem.Command" id="menu_go_to_parent">
+        <property name="command" type="command" cbtype="simple">on_context_menu_go_to_parent_clicked</property>
+        <property name="label" translatable="yes">Go to parent</property>
+      </object>
+    </child>
+    <child>
+      <object class="tk.Menuitem.Separator" id="sep_context" />
+    </child>
+    <child>
       <object class="tk.Menuitem.Command" id="menu_copy">
         <property name="command" type="command" cbtype="simple">on_context_menu_copy_clicked</property>
         <property name="label" translatable="yes">Copy</property>

--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -487,6 +487,10 @@ class WidgetsTreeEditor(object):
                     i,
                     s))
 
+        # No widget/item is currently selected anymore because
+        # we've just deleted selected items from the treeview.
+        self.current_edit = None
+
         # restore filter
         self.filter_restore()
 
@@ -881,6 +885,7 @@ class WidgetsTreeEditor(object):
             self.treeview.delete(*children)
         self.editor_hide_all()
         self.counter.clear()  # Reset the widget counter (August 19, 2021)
+        self.current_edit = None  # We no longer have a selected item in the treeview
 
     def load_file(self, filename):
         """Load file into treeview"""


### PR DESCRIPTION
Sometimes it's not easy to find the parent of the selected item, especially with a long hierarchy.
A new context command menu, 'Go to parent', will make it easier to quickly find and select the parent of the current item.
![go_to_parent](https://user-images.githubusercontent.com/45316730/159104746-36281893-2f0e-4bb0-b7e2-948c6a0d9d5e.png)

