### PR TITLE
Fix preview not updating when moving widgets that don't require a layout such as Notebook Tab

### DIFF
--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -572,7 +572,7 @@ class WidgetsTreeEditor(object):
         treelabel = '{0}: {1}'.format(data.identifier, data.classname)
         row = col = ''
         if root != '' and data.has_layout_defined():
-            if data.manager == 'grid' and data.layout_required:
+            if data.manager == 'grid':
                 row = data.layout_property('row')
                 col = data.layout_property('column')
                 # Fix grid row position when using copy and paste

--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -572,7 +572,7 @@ class WidgetsTreeEditor(object):
         treelabel = '{0}: {1}'.format(data.identifier, data.classname)
         row = col = ''
         if root != '' and data.has_layout_defined():
-            if data.manager == 'grid':
+            if data.manager == 'grid' and data.layout_required:
                 row = data.layout_property('row')
                 col = data.layout_property('column')
                 # Fix grid row position when using copy and paste
@@ -1107,9 +1107,14 @@ class WidgetsTreeEditor(object):
             if prev:
                 prev_idx = tree.index(prev)
                 tree.move(item, parent, prev_idx)
-                manager = self.treedata[item].manager
+                item_data = self.treedata[item]
+                manager = item_data.manager
+                layout_required = item_data.layout_required
                 self.app.set_changed()
-                if manager in ('pack', 'place'):
+
+                # Always refresh preview for objects that don't
+                # require a layout, such as menus and notebook tabs.
+                if manager in ('pack', 'place') or not layout_required:
                     self.draw_widget(item)
             self.filter_restore()
 
@@ -1124,9 +1129,14 @@ class WidgetsTreeEditor(object):
             if next:
                 next_idx = tree.index(next)
                 tree.move(item, parent, next_idx)
-                manager = self.treedata[item].manager
+                item_data = self.treedata[item]
+                manager = item_data.manager
+                layout_required = item_data.layout_required
                 self.app.set_changed()
-                if manager in ('pack', 'place'):
+
+                # Always refresh preview for objects that don't
+                # require a layout, such as menus and notebook tabs.                
+                if manager in ('pack', 'place') or not layout_required:
                     self.draw_widget(item)
             self.filter_restore()
 


### PR DESCRIPTION
### Fix preview not updating when moving widgets that don't require a layout such as Notebook Tab.

**Problem:**
When the default manager is 'grid', some objects, such as Menu Commands and Notebook Tabs, don't show changes in the preview canvas when the item's tree order has changed (Ctrl+I, Ctrl+K).
 
**How to reproduce the bug:**
1. Start a new Pygubu project
2. Make the preferred manager 'grid' (in Edit->Preferences)
3. Add a Notebook (under 'Containers')
4. Add two Notebook Tabs (under Pygubu Helpers)
5. Add a single button to each of the two tabs.
6. Highlight one of the tabs in the tree widget.
7. Press Ctrl+I or Ctrl+K to move the widget up/down in the treeview.
8. The changes don't update the preview.

Example of preview not refreshing when moving notebook tab using Ctrl+I and Ctrl+K:
![no_change](https://user-images.githubusercontent.com/45316730/162600582-ddf53168-cf7c-4d0d-8f53-f7fd5d05e008.gif)


The same thing happens when attempting to move a MenuItem.Command.

**Research:**
The reason why some widgets don't refresh is because the methods `on_item_move_up()` and `on_item_move_down()` will only refresh the preview if the manager is 'pack' or 'place'. 

However, when 'grid' is the default manager, those methods will see 'grid' as the manager of widgets such as Notebook Tab and Menu Commands, which causes the preview not to refresh.

Widgets/objects such as Notebook Tabs and Menu Commands don't use regular managers, so those types of widgets should refresh the preview when they are moved, regardless of the default geometry manager.

**Solution:**
I noticed that Notebook Tabs and Menu Commands (as well as some other widgets) have a property called 'layout_required' which is a boolean. So I used that as an indicator. If `layout_required` is False for the object that is being moved, then the preview will refresh, regardless of the geometry manager that it's using.

Example of the fixed version when using Ctrl+I and Ctrl+K:
![changes](https://user-images.githubusercontent.com/45316730/162600642-bfa0af0e-09cd-4481-b11b-8caea3e582e2.gif)

