### PR TITLE
Prevent the row/col numbers from showing for widgets that don't require a layout

### DIFF
--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -572,7 +572,7 @@ class WidgetsTreeEditor(object):
         treelabel = '{0}: {1}'.format(data.identifier, data.classname)
         row = col = ''
         if root != '' and data.has_layout_defined():
-            if data.manager == 'grid':
+            if data.manager == 'grid' and data.layout_required:
                 row = data.layout_property('row')
                 col = data.layout_property('column')
                 # Fix grid row position when using copy and paste
@@ -1039,7 +1039,7 @@ class WidgetsTreeEditor(object):
             if item_text != tree.item(item, 'text'):
                 tree.item(item, text=item_text)
             # if tree.parent(item) != '' and 'layout' in data:
-            if tree.parent(item) != '':
+            if tree.parent(item) != '' and data.layout_required:
                 if data.manager == 'grid':
                     row = data.layout_property('row')
                     col = data.layout_property('column')


### PR DESCRIPTION
When using grid, prevent the row/col numbers from showing in the object treeview for widgets that don't require layouts, such as a Notebook Tab and Command menus.

### Before:
![grid_info](https://user-images.githubusercontent.com/45316730/162835011-0f58444e-eac4-4699-b2bf-fd1aee0eb2af.png)

### After:
![no_grid_info](https://user-images.githubusercontent.com/45316730/162835091-9d48c48a-3d13-4767-b96c-f5bcdf30aa08.png)

