### PR TITLE
Fix: 'filedialog.askopenfilename' is blocked by 'preferences.dialog'.

### DIFF
--- a/pygubudesigner/__init__.py
+++ b/pygubudesigner/__init__.py
@@ -40,7 +40,7 @@ def get_requirements():
             ">=22.1.0",
             "MIT License",
             "https://github.com/psf/black",
-        ), 
+        ),
     ]
 
 

--- a/pygubudesigner/preferences.py
+++ b/pygubudesigner/preferences.py
@@ -147,6 +147,7 @@ class PreferencesUI:
         self.master = master
         self.translator = translator
         self.dialog = None
+        self.dialog_toplevel = None
         self.builder = None
         self._create_preferences_dialog()
         self._load_options()
@@ -158,6 +159,7 @@ class PreferencesUI:
 
         top = self.master.winfo_toplevel()
         self.dialog = dialog = builder.get_object("preferences", top)
+        self.dialog_toplevel = self.dialog.toplevel
 
         self.v_style_definition_file = builder.get_variable(
             "v_style_definition_file"
@@ -235,7 +237,9 @@ class PreferencesUI:
             "defaultextension": ".py",
             "filetypes": ((_("Python module"), "*.py"), (_("All"), "*.*")),
         }
-        fname = filedialog.asksaveasfilename(**options)
+        fname = filedialog.asksaveasfilename(
+            parent=self.dialog_toplevel, **options
+        )
         if not fname:
             return
 
@@ -266,7 +270,9 @@ class PreferencesUI:
             "defaultextension": ".py",
             "filetypes": ((_("Python module"), "*.py"), (_("All"), "*.*")),
         }
-        fname = filedialog.askopenfilename(**options)
+        fname = filedialog.askopenfilename(
+            parent=self.dialog_toplevel, **options
+        )
         if fname:
             self.v_style_definition_file.set(fname)
 
@@ -302,7 +308,9 @@ class PreferencesUI:
             "defaultextension": ".py",
             "filetypes": ((_("Python module"), "*.py"), (_("All"), "*.*")),
         }
-        fname = filedialog.askopenfilename(**options)
+        fname = filedialog.askopenfilename(
+            parent=self.dialog_toplevel, **options
+        )
         if fname:
             self.cwtv.insert("", tk.END, text=fname)
             self._configure_path_remove()


### PR DESCRIPTION
# Fix: 'filedialog.askopenfilename' is blocked by 'preferences.dialog'.  
## Before changes:  
![Screenshot from 2022-07-14 21-50-22](https://user-images.githubusercontent.com/24457116/179002890-2609fab6-e0b3-4778-9490-25a6d1d86ccd.png)
 ## After changes:  
![Screenshot from 2022-07-14 22-05-43](https://user-images.githubusercontent.com/24457116/179002989-d8a46b08-b091-4a2d-af79-ffdeb693d355.png)

