### PR TITLE
Fix template path in preferences window

### DIFF
--- a/src/pygubudesigner/preferences.py
+++ b/src/pygubudesigner/preferences.py
@@ -56,7 +56,7 @@ config.add_section(SEC_RECENT_FILES)
 
 DATA_DIR = Path(__file__).parent / "data"
 TEMPLATE_DIR = DATA_DIR / "codegen" / "template"
-NEW_STYLE_FILE_TEMPLATE = TEMPLATE_DIR / "customstyles.py.mako"
+NEW_STYLE_FILE_TEMPLATE = DATA_DIR / "code_templates" / "customstyles.py.mako"
 
 
 def initialize_configfile():

--- a/src/pygubudesigner/preferences.py
+++ b/src/pygubudesigner/preferences.py
@@ -55,8 +55,8 @@ config.add_section(SEC_GENERAL)
 config.add_section(SEC_RECENT_FILES)
 
 DATA_DIR = Path(__file__).parent / "data"
-TEMPLATE_DIR = DATA_DIR / "codegen" / "template"
-NEW_STYLE_FILE_TEMPLATE = DATA_DIR / "code_templates" / "customstyles.py.mako"
+TEMPLATE_DIR = DATA_DIR / "code_templates"
+NEW_STYLE_FILE_TEMPLATE = TEMPLATE_DIR / "customstyles.py.mako"
 
 
 def initialize_configfile():


### PR DESCRIPTION
In the Preferences window -> Ttk Styles tab, when the 'Create New...' button is clicked (to create a new style template file), it can't find the mako template file, so it shows an error. This pull request corrects the template path.