### PR TITLE
Setting for single section toolbar

### DIFF
--- a/src/pygubudesigner/data/ui/preferences_dialog.ui
+++ b/src/pygubudesigner/data/ui/preferences_dialog.ui
@@ -150,6 +150,20 @@
                             </layout>
                           </object>
                         </child>
+                        <child>
+                          <object class="ttk.Checkbutton" id="chk_single_section">
+                            <property name="offvalue">no</property>
+                            <property name="onvalue">yes</property>
+                            <property name="text" translatable="yes">Single section widgets toolbar (requires restart)</property>
+                            <property name="variable">string:single_section</property>
+                            <layout manager="grid">
+                              <property name="column">0</property>
+                              <property name="pady">4</property>
+                              <property name="row">5</property>
+                              <property name="sticky">w</property>
+                            </layout>
+                          </object>
+                        </child>
                       </object>
                     </child>
                     <child>

--- a/src/pygubudesigner/main.py
+++ b/src/pygubudesigner/main.py
@@ -507,7 +507,8 @@ class PygubuDesigner:
             pass
 
         treelist = self.create_treelist()
-        self._pallete = ComponentPalette(fpalette)
+        self._pallete = ComponentPalette(fpalette, notebook=(
+            pref.get_option("single_section") == "no"))
 
         # Start building widget tree selector
         roots = {}

--- a/src/pygubudesigner/main.py
+++ b/src/pygubudesigner/main.py
@@ -507,7 +507,7 @@ class PygubuDesigner:
             pass
 
         treelist = self.create_treelist()
-        self._pallete = ComponentPalette(fpalette, notebook=(
+        self._palette = ComponentPalette(fpalette, notebook=(
             pref.get_option("single_section") == "no"))
 
         # Start building widget tree selector
@@ -516,7 +516,7 @@ class PygubuDesigner:
         for key, wc in treelist:
             root, section = key.split(">")
             if section not in sections:
-                roots[root] = self._pallete.add_tab(section, section)
+                roots[root] = self._palette.add_tab(section, section)
                 sections[section] = 1
 
             # insert widget
@@ -534,11 +534,11 @@ class PygubuDesigner:
             if wlabel.startswith("Menuitem."):
                 wlabel = wlabel.replace("Menuitem.", "")
             callback = create_cb(wc.classname)
-            self._pallete.add_button(
+            self._palette.add_button(
                 section, root, wlabel, wc.classname, w_image, callback
             )
         default_group = pref.get_option("widget_set")
-        self._pallete.show_group(default_group)
+        self._palette.show_group(default_group)
 
     def on_add_widget_event(self, classname):
         """Adds a widget to the widget tree."""

--- a/src/pygubudesigner/preferences.py
+++ b/src/pygubudesigner/preferences.py
@@ -34,6 +34,10 @@ options = {
         "values": '["yes", "no"]',
         "default": "no",
     },
+    "single_section": {
+        "values": '["yes", "no"]',
+        "default": "no",
+    },
     "geometry": {
         "default": "640x480",
     },

--- a/src/pygubudesigner/widgets/componentpalette.py
+++ b/src/pygubudesigner/widgets/componentpalette.py
@@ -24,8 +24,8 @@ from .toolbarframe import ToolbarFrame
 class ComponentPalette(ttk.Frame):
     def __init__(self, master=None, notebook=True, **kw):
         ttk.Frame.__init__(self, master, **kw)
-        component_pallete = ttk.Frame(master)
-        fbuttons = ttk.Frame(component_pallete)
+        component_palette = ttk.Frame(master)
+        fbuttons = ttk.Frame(component_palette)
         fbuttons.configure(padding=1)
         rb_tk = ttk.Radiobutton(fbuttons)
         self.gvalue = gvalue = tk.StringVar(value="")
@@ -47,7 +47,7 @@ class ComponentPalette(ttk.Frame):
         )
         rb_ttk.pack(expand="true", fill="both", side="top")
         fbuttons.pack(fill="y", side="left")
-        fbntab = ttk.Frame(component_pallete)
+        fbntab = ttk.Frame(component_palette)
         if notebook:
             self.notebook = ttk.Notebook(fbntab)
             self.notebook.config(
@@ -63,9 +63,8 @@ class ComponentPalette(ttk.Frame):
             self.frame.pack(side="top", expand=True, fill="both")
         fbntab.config(height="200", width="200")
         fbntab.pack(side="left", expand=True, fill="x")
-        component_pallete.config(height="200", padding="2", width="200")
-        component_pallete.pack(side="top", expand=True, fill="x")
-
+        component_palette.config(height="200", padding="2", width="200")
+        component_palette.pack(side="top", expand=True, fill="x")
         self._tabs = {}
         self._buttons = []
 

--- a/src/pygubudesigner/widgets/componentpalette.py
+++ b/src/pygubudesigner/widgets/componentpalette.py
@@ -22,7 +22,7 @@ from .toolbarframe import ToolbarFrame
 
 
 class ComponentPalette(ttk.Frame):
-    def __init__(self, master=None, **kw):
+    def __init__(self, master=None, notebook=True, **kw):
         ttk.Frame.__init__(self, master, **kw)
         component_pallete = ttk.Frame(master)
         fbuttons = ttk.Frame(component_pallete)
@@ -48,14 +48,19 @@ class ComponentPalette(ttk.Frame):
         rb_ttk.pack(expand="true", fill="both", side="top")
         fbuttons.pack(fill="y", side="left")
         fbntab = ttk.Frame(component_pallete)
-        self.notebook = notebook = ttk.Notebook(fbntab)
-        notebook.config(
-            height="50",
-            width="300",
-            style="ComponentPalette.TNotebook",
-            takefocus=True,
-        )
-        notebook.pack(side="top", expand=True, fill="x")
+        if notebook:
+            self.notebook = ttk.Notebook(fbntab)
+            self.notebook.config(
+                height="50",
+                width="300",
+                style="ComponentPalette.TNotebook",
+                takefocus=True,
+            )
+            self.notebook.pack(side="top", expand=True, fill="x")
+        else:
+            self.notebook = None
+            self.frame = ToolbarFrame(fbntab)
+            self.frame.pack(side="top", expand=True, fill="both")
         fbntab.config(height="200", width="200")
         fbntab.pack(side="left", expand=True, fill="x")
         component_pallete.config(height="200", padding="2", width="200")
@@ -72,6 +77,8 @@ class ComponentPalette(ttk.Frame):
 
     def add_tab(self, tabid, label):
         # frame_1 = ttk.Frame(self.notebook)
+        if not self.notebook:
+            return
         frame_1 = ToolbarFrame(self.notebook)
         frame_1.configure(padding=2)
         frame_1.pack(expand="true", fill="both", side="top")
@@ -79,7 +86,7 @@ class ComponentPalette(ttk.Frame):
         self._tabs[tabid] = frame_1
 
     def add_button(self, tabid, group, label, ttiplabel, image, callback):
-        master = self._tabs[tabid].child_master()
+        master = self._tabs[tabid].child_master() if self.notebook else self.frame.child_master()
         # master = self._tabs[tabid]
         b = ttk.Button(
             master,

--- a/src/pygubudesigner/widgets/toolbarframe.py
+++ b/src/pygubudesigner/widgets/toolbarframe.py
@@ -140,9 +140,13 @@ class ToolbarFrame(ttk.Frame):
     def scroll_right(self):
         newstart = self.fcstart - self.SCROLL_INCREMENT
         cw = self.fcontent.winfo_reqwidth()
-        limit = cw - self.SCROLL_INCREMENT
+        f_width = self.fvport.winfo_width()
+        limit = cw - f_width
         if newstart > -(limit):
             self.fcstart = newstart
+            self.fcontent.place(x=self.fcstart)
+        elif self.fcstart != -limit:
+            self.fcstart = -limit
             self.fcontent.place(x=self.fcstart)
 
     def scroll_left(self):

--- a/src/pygubudesigner/widgets/toolbarframe.py
+++ b/src/pygubudesigner/widgets/toolbarframe.py
@@ -150,6 +150,9 @@ class ToolbarFrame(ttk.Frame):
         if newstart <= 0:
             self.fcstart = newstart
             self.fcontent.place(x=self.fcstart)
+        elif self.fcstart < 0:
+            self.fcstart = 0
+            self.fcontent.place(x=self.fcstart)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I got a pretty wide monitor and the first thing that bothered me a little about the UI, was that there's a couple of different tabs that only hold a handful of widgets,
and switching back and forth to go through what I might need next got annoying pretty fast.

So I tried to fit them all into a single frame instead. Took a while of digging through the code and how the UI works but I eventually managed to make it look like this:
![image](https://github.com/alejandroautalan/pygubu-designer/assets/1014362/e3723ce9-f45a-4a0f-83c1-5aeda3d6777f)

What I did not yet figure out is, how to make the setting hot-swap capable. Because I still don't fully understand how the designers UI is constructed,
I didn't dare to interfere with the toolbar by reconstructing it on a settings change, so it instead requires a restart.

The changes also include small tweaks to the ToolbarFrame used, as there were a few quirks with it's scrolling.
For one did it scroll to the end by leaving 2/3rds of it's width empty for no good reason,
and another was that if the window was shrunk, it could become impossible to scroll back to the beginning.

I also couldn't help to fix the typos of "pallete". I am aware that this might break other forks, so if that's a concern, I'll remove that commit and resubmit the PR.