### PR TITLE
Generate code type hints for app and script + optional run parameter to center main window

### DIFF
--- a/src/pygubudesigner/codegen/codebuilder.py
+++ b/src/pygubudesigner/codegen/codebuilder.py
@@ -79,6 +79,7 @@ class UI2Code(Builder):
         self._extra_imports = {}
         self._code_imports = OrderedDict()
         self._tkvariables = {}
+        self._tkvariablehints = {}
         self._tkimages = {}
         self._callbacks = {}
         self._import_tk = False
@@ -139,6 +140,7 @@ class UI2Code(Builder):
             "ttkstyles": code_ttk_styles,
             "callbacks": code_callbacks,
             "tkvariables": list(self._tkvariables.keys()),
+            "tkvariablehints": self._tkvariablehints,
             "methods": code_methods,
         }
         return cc
@@ -352,6 +354,7 @@ class UI2Code(Builder):
             line = f"{vname_in_code} = {var_create}"
             self._add_new_code([line])
             self._tkvariables[vname] = vname_in_code
+            self._tkvariablehints[vname] = var_create.split("(")[0]
             self._import_tk = True
         return self._tkvariables[vname]
 

--- a/src/pygubudesigner/codegen/scriptgenerator.py
+++ b/src/pygubudesigner/codegen/scriptgenerator.py
@@ -157,6 +157,7 @@ class ScriptGenerator:
                 # Tk Variables
                 if self.import_tkvars_var.get():
                     context["tkvariables"] = code["tkvariables"]
+                    context["tkvariablehints"] = code["tkvariablehints"]
                 tpl = makolookup.get_template("app.py.mako")
                 final_code = tpl.render(**context)
                 final_code = self._format_code(final_code)

--- a/src/pygubudesigner/codegen/scriptgenerator.py
+++ b/src/pygubudesigner/codegen/scriptgenerator.py
@@ -137,8 +137,8 @@ class ScriptGenerator:
 
             if template == "application":
                 generator.add_import_line("pathlib")
-                if not main_widget_is_toplevel:
-                    generator.add_import_line("tkinter", "tk", priority=1)
+                # if not main_widget_is_toplevel:
+                generator.add_import_line("tkinter", "tk", priority=1)
                 if self.use_ttkdefs_file_var.get():
                     generator.add_import_line("tkinter.ttk", "ttk", priority=1)
                 generator.add_import_line("pygubu", priority=10)

--- a/src/pygubudesigner/data/code_templates/app.py.mako
+++ b/src/pygubudesigner/data/code_templates/app.py.mako
@@ -46,7 +46,10 @@ class ${class_name}:
             x_min = self.mainwindow.wm_minsize()[0]
             y_min = self.mainwindow.wm_minsize()[1]
             geom = self.builder.objects[list(self.builder.objects)[0]]
-            geom = geom.wmeta.properties["geometry"].split("x")
+            if "geometry" in geom.wmeta.properties:
+                geom = geom.wmeta.properties["geometry"].split("x")
+            else:
+                geom = (0,0)
             x_min = max(x_min, int(geom[0]), self.mainwindow.winfo_reqwidth())
             y_min = max(y_min, int(geom[1]), self.mainwindow.winfo_reqheight())
             x = self.mainwindow.winfo_screenwidth() - x_min

--- a/src/pygubudesigner/data/code_templates/app.py.mako
+++ b/src/pygubudesigner/data/code_templates/app.py.mako
@@ -45,11 +45,10 @@ class ${class_name}:
         if center:
             x_min = self.mainwindow.wm_minsize()[0]
             y_min = self.mainwindow.wm_minsize()[1]
-            if x_min == 1 or y_min == 1:
-                geom = self.builder.objects[list(self.builder.objects)[0]]
-                geom = geom.wmeta.properties["geometry"].split("x")
-                x_min = int(geom[0])
-                y_min = int(geom[1])
+            geom = self.builder.objects[list(self.builder.objects)[0]]
+            geom = geom.wmeta.properties["geometry"].split("x")
+            x_min = max(x_min, int(geom[0]), self.mainwindow.winfo_reqwidth())
+            y_min = max(y_min, int(geom[1]), self.mainwindow.winfo_reqheight())
             x = self.mainwindow.winfo_screenwidth() - x_min
             y = self.mainwindow.winfo_screenheight() - y_min
             self.mainwindow.geometry(f"+{x // 2}+{y // 2}")

--- a/src/pygubudesigner/data/code_templates/app.py.mako
+++ b/src/pygubudesigner/data/code_templates/app.py.mako
@@ -25,7 +25,7 @@ class ${class_name}:
         builder.add_resource_path(PROJECT_PATH)
         builder.add_from_file(PROJECT_UI)
         # Main widget
-        self.mainwindow = builder.get_object("${main_widget}", master)
+        self.mainwindow: tk.Toplevel = builder.get_object("${main_widget}", master)
 %if set_main_menu:
         # Main menu
         _main_menu = builder.get_object("${main_menu_id}", self.mainwindow)

--- a/src/pygubudesigner/data/code_templates/app.py.mako
+++ b/src/pygubudesigner/data/code_templates/app.py.mako
@@ -41,7 +41,11 @@ class ${class_name}:
         %endif
         builder.connect_callbacks(self)
 
-    def run(self):
+    def run(self, center=False):
+        if center:
+            x = self.mainwindow.winfo_screenwidth() - self.mainwindow.wm_minsize()[0]
+            y = self.mainwindow.winfo_screenheight() - self.mainwindow.wm_minsize()[1]
+            self.mainwindow.geometry(f"+{x // 2}+{y // 2}")
         self.mainwindow.mainloop()
     %if has_ttk_styles:
 

--- a/src/pygubudesigner/data/code_templates/app.py.mako
+++ b/src/pygubudesigner/data/code_templates/app.py.mako
@@ -25,7 +25,7 @@ class ${class_name}:
         builder.add_resource_path(PROJECT_PATH)
         builder.add_from_file(PROJECT_UI)
         # Main widget
-        self.mainwindow: ${widget_base_class} = builder.get_object("${main_widget}", master)
+        self.mainwindow:${widget_base_class} = builder.get_object("${main_widget}", master)
 %if set_main_menu:
         # Main menu
         _main_menu = builder.get_object("${main_menu_id}", self.mainwindow)
@@ -43,8 +43,15 @@ class ${class_name}:
 
     def run(self, center=False):
         if center:
-            x = self.mainwindow.winfo_screenwidth() - self.mainwindow.wm_minsize()[0]
-            y = self.mainwindow.winfo_screenheight() - self.mainwindow.wm_minsize()[1]
+            x_min = self.mainwindow.wm_minsize()[0]
+            y_min = self.mainwindow.wm_minsize()[1]
+            if x_min == 1 or y_min == 1:
+                geom = self.builder.objects[list(self.builder.objects)[0]]
+                geom = geom.wmeta.properties["geometry"].split("x")
+                x_min = int(geom[0])
+                y_min = int(geom[1])
+            x = self.mainwindow.winfo_screenwidth() - x_min
+            y = self.mainwindow.winfo_screenheight() - y_min
             self.mainwindow.geometry(f"+{x // 2}+{y // 2}")
         self.mainwindow.mainloop()
 

--- a/src/pygubudesigner/data/code_templates/app.py.mako
+++ b/src/pygubudesigner/data/code_templates/app.py.mako
@@ -31,14 +31,14 @@ class ${class_name}:
         _main_menu = builder.get_object("${main_menu_id}", self.mainwindow)
         self.mainwindow.configure(menu=_main_menu)
 %endif
-        %if tkvariables:
+    %if tkvariables:
 
-          %for var in tkvariables:
-        self.${var} = None
-          %endfor
-        builder.import_variables(self, ${tkvariables})
+        %for var in tkvariables:
+        self.${var}:${tkvariablehints[var]} = None
+        %endfor
+        builder.import_variables(self)
 
-        %endif
+    %endif
         builder.connect_callbacks(self)
 
     def run(self, center=False):

--- a/src/pygubudesigner/data/code_templates/app.py.mako
+++ b/src/pygubudesigner/data/code_templates/app.py.mako
@@ -41,20 +41,7 @@ class ${class_name}:
     %endif
         builder.connect_callbacks(self)
 
-    def run(self, center=False):
-        if center:
-            x_min = self.mainwindow.wm_minsize()[0]
-            y_min = self.mainwindow.wm_minsize()[1]
-            geom = self.builder.objects[list(self.builder.objects)[0]]
-            if "geometry" in geom.wmeta.properties:
-                geom = geom.wmeta.properties["geometry"].split("x")
-            else:
-                geom = (0,0)
-            x_min = max(x_min, int(geom[0]), self.mainwindow.winfo_reqwidth())
-            y_min = max(y_min, int(geom[1]), self.mainwindow.winfo_reqheight())
-            x = self.mainwindow.winfo_screenwidth() - x_min
-            y = self.mainwindow.winfo_screenheight() - y_min
-            self.mainwindow.geometry(f"+{x // 2}+{y // 2}")
+    def run(self):
         self.mainwindow.mainloop()
 
 ${callbacks}\

--- a/src/pygubudesigner/data/code_templates/app.py.mako
+++ b/src/pygubudesigner/data/code_templates/app.py.mako
@@ -25,7 +25,7 @@ class ${class_name}:
         builder.add_resource_path(PROJECT_PATH)
         builder.add_from_file(PROJECT_UI)
         # Main widget
-        self.mainwindow: tk.Toplevel = builder.get_object("${main_widget}", master)
+        self.mainwindow: ${widget_base_class} = builder.get_object("${main_widget}", master)
 %if set_main_menu:
         # Main menu
         _main_menu = builder.get_object("${main_menu_id}", self.mainwindow)

--- a/src/pygubudesigner/data/code_templates/script.py.mako
+++ b/src/pygubudesigner/data/code_templates/script.py.mako
@@ -24,11 +24,10 @@ ${widget_code}
         if center:
             x_min = self.mainwindow.wm_minsize()[0]
             y_min = self.mainwindow.wm_minsize()[1]
-            if x_min == 1 or y_min == 1:
-                geom = self.builder.objects[list(self.builder.objects)[0]]
-                geom = geom.wmeta.properties["geometry"].split("x")
-                x_min = int(geom[0])
-                y_min = int(geom[1])
+            geom = self.builder.objects[list(self.builder.objects)[0]]
+            geom = geom.wmeta.properties["geometry"].split("x")
+            x_min = max(x_min, int(geom[0]), self.mainwindow.winfo_reqwidth())
+            y_min = max(y_min, int(geom[1]), self.mainwindow.winfo_reqheight())
             x = self.mainwindow.winfo_screenwidth() - x_min
             y = self.mainwindow.winfo_screenheight() - y_min
             self.mainwindow.geometry(f"+{x // 2}+{y // 2}")

--- a/src/pygubudesigner/data/code_templates/script.py.mako
+++ b/src/pygubudesigner/data/code_templates/script.py.mako
@@ -25,7 +25,10 @@ ${widget_code}
             x_min = self.mainwindow.wm_minsize()[0]
             y_min = self.mainwindow.wm_minsize()[1]
             geom = self.builder.objects[list(self.builder.objects)[0]]
-            geom = geom.wmeta.properties["geometry"].split("x")
+            if "geometry" in geom.wmeta.properties:
+                geom = geom.wmeta.properties["geometry"].split("x")
+            else:
+                geom = (0,0)
             x_min = max(x_min, int(geom[0]), self.mainwindow.winfo_reqwidth())
             y_min = max(y_min, int(geom[1]), self.mainwindow.winfo_reqheight())
             x = self.mainwindow.winfo_screenwidth() - x_min

--- a/src/pygubudesigner/data/code_templates/script.py.mako
+++ b/src/pygubudesigner/data/code_templates/script.py.mako
@@ -20,7 +20,18 @@ ${widget_code}
         self.mainwindow.configure(menu=_main_menu)
 %endif
 
-    def run(self):
+    def run(self, center=False):
+        if center:
+            x_min = self.mainwindow.wm_minsize()[0]
+            y_min = self.mainwindow.wm_minsize()[1]
+            if x_min == 1 or y_min == 1:
+                geom = self.builder.objects[list(self.builder.objects)[0]]
+                geom = geom.wmeta.properties["geometry"].split("x")
+                x_min = int(geom[0])
+                y_min = int(geom[1])
+            x = self.mainwindow.winfo_screenwidth() - x_min
+            y = self.mainwindow.winfo_screenheight() - y_min
+            self.mainwindow.geometry(f"+{x // 2}+{y // 2}")
         self.mainwindow.mainloop()
 
 ${methods}\

--- a/src/pygubudesigner/data/code_templates/script.py.mako
+++ b/src/pygubudesigner/data/code_templates/script.py.mako
@@ -20,20 +20,7 @@ ${widget_code}
         self.mainwindow.configure(menu=_main_menu)
 %endif
 
-    def run(self, center=False):
-        if center:
-            x_min = self.mainwindow.wm_minsize()[0]
-            y_min = self.mainwindow.wm_minsize()[1]
-            geom = self.builder.objects[list(self.builder.objects)[0]]
-            if "geometry" in geom.wmeta.properties:
-                geom = geom.wmeta.properties["geometry"].split("x")
-            else:
-                geom = (0,0)
-            x_min = max(x_min, int(geom[0]), self.mainwindow.winfo_reqwidth())
-            y_min = max(y_min, int(geom[1]), self.mainwindow.winfo_reqheight())
-            x = self.mainwindow.winfo_screenwidth() - x_min
-            y = self.mainwindow.winfo_screenheight() - y_min
-            self.mainwindow.geometry(f"+{x // 2}+{y // 2}")
+    def run(self):
         self.mainwindow.mainloop()
 
 ${methods}\


### PR DESCRIPTION
I wanted some type hinting support for the defined TkVars in VSCode, so I've expanded the `app` and `script` mako files for that.

And I also found it way to bothersome to write some code that (optionally) centers the window upon creation, so I've added that to the mako files as well.

This is what it then looks like for variables:
![image](https://github.com/alejandroautalan/pygubu-designer/assets/1014362/908dcfa2-58fe-4d7e-aa06-18fdb4982785)
