### PR TITLE
Center main widget code for mako templates

### DIFF
--- a/src/pygubudesigner/data/code_templates/app.py.mako
+++ b/src/pygubudesigner/data/code_templates/app.py.mako
@@ -41,7 +41,28 @@ class ${class_name}:
     %endif
         builder.connect_callbacks(self)
 
-    def run(self):
+    def center(self, event):
+        """ `winfo_width` / `winfo_height` at this point return set `geometry` size. """
+        x_min = max(self.main_w,
+            self.mainwindow.wm_minsize()[0],
+            self.mainwindow.winfo_width(),
+            self.mainwindow.winfo_reqwidth())
+        y_min = max(self.main_h,
+            self.mainwindow.wm_minsize()[1],
+            self.mainwindow.winfo_height(),
+            self.mainwindow.winfo_reqheight())
+        x = self.mainwindow.winfo_screenwidth() - x_min
+        y = self.mainwindow.winfo_screenheight() - y_min
+        self.mainwindow.geometry(f"{x_min}x{y_min}+{x // 2}+{y // 2}")
+        self.mainwindow.unbind("<Map>", self.center_map)
+
+    def run(self, center=False):
+        if center:
+            """ If `width` and `height` are set for the main widget,
+            this is the only time TK returns them. """
+            self.main_w = self.mainwindow.winfo_reqwidth()
+            self.main_h = self.mainwindow.winfo_reqheight()
+            self.center_map = self.mainwindow.bind("<Map>", self.center)
         self.mainwindow.mainloop()
 
 ${callbacks}\

--- a/src/pygubudesigner/data/code_templates/script.py.mako
+++ b/src/pygubudesigner/data/code_templates/script.py.mako
@@ -20,7 +20,28 @@ ${widget_code}
         self.mainwindow.configure(menu=_main_menu)
 %endif
 
-    def run(self):
+    def center(self, event):
+        """ `winfo_width` / `winfo_height` at this point return set `geometry` size. """
+        x_min = max(self.main_w,
+            self.mainwindow.wm_minsize()[0],
+            self.mainwindow.winfo_width(),
+            self.mainwindow.winfo_reqwidth())
+        y_min = max(self.main_h,
+            self.mainwindow.wm_minsize()[1],
+            self.mainwindow.winfo_height(),
+            self.mainwindow.winfo_reqheight())
+        x = self.mainwindow.winfo_screenwidth() - x_min
+        y = self.mainwindow.winfo_screenheight() - y_min
+        self.mainwindow.geometry(f"{x_min}x{y_min}+{x // 2}+{y // 2}")
+        self.mainwindow.unbind("<Map>", self.center_map)
+
+    def run(self, center=False):
+        if center:
+            """ If `width` and `height` are set for the main widget,
+            this is the only time TK returns them. """
+            self.main_w = self.mainwindow.winfo_reqwidth()
+            self.main_h = self.mainwindow.winfo_reqheight()
+            self.center_map = self.mainwindow.bind("<Map>", self.center)
         self.mainwindow.mainloop()
 
 ${methods}\


### PR DESCRIPTION
I've done some more fiddling with the centering of the main widget and got a somewhat solid solution now which works with various combinations of `geometry`, `min_size` and `width` + `height`.
It will basically go through all and use the biggest it finds. This also "fixes" the "issue" that the window manager can end up overriding `width` + `height`.
If these are set and end up being the biggest values found, then the window will end up with exactly that size, instead of letting the manager have the last word and do *whatever* with that info.

The only remaining issue for me is, that it *can* still pop up for a single frame in the original position. It *seems* be a lot less likely to happen by setting size *and* position with `app.mainwindow.geometry()`, but it can still happen regardless.

But I guess most people wouldn't really care or even notice, so that's why I'm putting it out in this form.
I think the only way around the popping would be the 'original' solution, which basically asked the `.builder` what size the main window will *likely* end up being.