### PR TITLE
Add menu option to reset docked frames layout

### DIFF
--- a/src/pygubudesigner/data/ui/pygubu-ui.ui
+++ b/src/pygubudesigner/data/ui/pygubu-ui.ui
@@ -1,5 +1,27 @@
 <?xml version='1.0' encoding='utf-8'?>
-<interface version="1.4" author="PygubuDesigner 0.38">
+<interface version="1.4" author="PygubuDesigner 0.39">
+  <project>
+    <settings>
+      <setting id="name">pygubu-designer window</setting>
+      <setting id="description">This is the main pygubu-designer ui file.</setting>
+      <setting id="module_name">projectsettings</setting>
+      <setting id="output_dir">../../</setting>
+      <setting id="template">application</setting>
+      <setting id="main_widget">mainwindow</setting>
+      <setting id="main_classname">PygubuDesigner</setting>
+      <setting id="main_menu" />
+      <setting id="import_tkvariables">False</setting>
+      <setting id="use_ttk_styledefinition_file">False</setting>
+      <setting id="use_i18n">False</setting>
+      <setting id="all_ids_attributes">False</setting>
+      <setting id="generate_code_onsave">False</setting>
+      <setting id="use_window_centering_code">False</setting>
+      <setting id="ttk_style_definition_file" />
+    </settings>
+    <customwidgets>
+      <customwidget path="../../services/widgets/treecomponentpalettebo.py" />
+    </customwidgets>
+  </project>
   <object class="tk.Menu" id="mainmenu">
     <property name="tearoff">0</property>
     <child>
@@ -165,6 +187,15 @@
         </child>
         <child>
           <object class="tk.Menuitem.Separator" id="edit_Separator2" />
+        </child>
+        <child>
+          <object class="tk.Menuitem.Command" id="reset_layout" named="True">
+            <property name="command" type="command" cbtype="with_wid">on_edit_menuitem_clicked</property>
+            <property name="label" translatable="yes">Reset layout</property>
+          </object>
+        </child>
+        <child>
+          <object class="tk.Menuitem.Separator" id="separator2" />
         </child>
         <child>
           <object class="tk.Menuitem.Command" id="edit_preferences">
@@ -770,26 +801,4 @@
       </object>
     </child>
   </object>
-  <project>
-    <settings>
-      <setting id="name">pygubu-designer window</setting>
-      <setting id="description">This is the main pygubu-designer ui file.</setting>
-      <setting id="module_name">projectsettings</setting>
-      <setting id="output_dir">../../</setting>
-      <setting id="template">application</setting>
-      <setting id="main_widget">mainwindow</setting>
-      <setting id="main_classname">PygubuDesigner</setting>
-      <setting id="main_menu" />
-      <setting id="import_tkvariables">False</setting>
-      <setting id="use_ttk_styledefinition_file">False</setting>
-      <setting id="use_i18n">False</setting>
-      <setting id="all_ids_attributes">False</setting>
-      <setting id="generate_code_onsave">False</setting>
-      <setting id="use_window_centering_code">False</setting>
-      <setting id="ttk_style_definition_file" />
-    </settings>
-    <customwidgets>
-      <customwidget path="../../services/widgets/treecomponentpalettebo.py" />
-    </customwidgets>
-  </project>
 </interface>

--- a/src/pygubudesigner/main.py
+++ b/src/pygubudesigner/main.py
@@ -724,10 +724,14 @@ proc ::tk::dialog::file::Create {w class} {
     def on_edit_menuitem_clicked(self, itemid):
         if itemid == "edit_preferences":
             self._edit_preferences()
+            
+        elif itemid == "reset_layout":
+            self._reset_layout()            
+            
         else:
             action = f"<<ACTION_{itemid}>>"
             self.mainwindow.event_generate(action)
-
+            
     # Project menu
     def on_project_menuitem_clicked(self, itemid):
         if itemid == "project_settings":
@@ -834,6 +838,14 @@ proc ::tk::dialog::file::Create {w class} {
             # self.preferences = pref.PreferencesUI(self.mainwindow, translator)
             self.preferences = DesignerSettings(self.mainwindow, translator)
         self.preferences.run()
+        
+    def _reset_layout(self):
+        """
+        Reset the docked frames back to their default positions.
+        """
+        self.on_dockframe_changed(reset_layout=True)
+        msg = _("Restart Pygubu Designer\nfor changes to take effect.")
+        messagebox.showinfo(self.mbox_title, msg, parent=self.mainwindow)         
 
     def _require_project_open(self):
         if self.current_project is None:
@@ -923,10 +935,25 @@ proc ::tk::dialog::file::Create {w class} {
                     det,
                 )
 
-    def on_dockframe_changed(self, event=None):
-        """Save current layout of maindock widget."""
-        dock = self.builder.get_object("maindock")
-        dock_layout = dock.save_layout()
+    def on_dockframe_changed(self, event=None, reset_layout=False):
+        """
+        Save current layout of maindock widget.
+        
+        Arguments:
+        
+        - event
+        
+        - reset_layout: used for resetting the docked frames
+        back to their default locations/positions.
+        """
+        
+        # Should we reset the layout back to the defaults?
+        if reset_layout:
+            dock_layout = None
+        else:
+            dock = self.builder.get_object("maindock")
+            dock_layout = dock.save_layout()
+            
         pref.save_maindock_layout(dock_layout)
 
     def load_dockframe_layout(self):


### PR DESCRIPTION
I started experimenting with different layouts using the docked frames in the new Pygubu Designer (which is really nice by the way). While I was experimenting with different layouts, I ended up making a mistake in my layout which caused Pygubu Designer to show up empty.

So I added a 'Reset layout' menu item in the 'Edit' menu to help in this situation.
![image](https://github.com/alejandroautalan/pygubu-designer/assets/45316730/de195327-90db-4e2d-97f2-05fe099da056)

